### PR TITLE
Update Stack.js

### DIFF
--- a/src/tracks/Stack.js
+++ b/src/tracks/Stack.js
@@ -95,7 +95,8 @@ export default class Stack extends Track {
     if (this.conf.direction === 'in') {
       return [
         Math.max(this.conf.outerRadius - radialEnd, this.conf.innerRadius),
-        this.conf.outerRadius - radialStart
+         Math.min( this.conf.outerRadius - radialStart, this.conf.innerRadius)
+       
       ]
     }
 


### PR DESCRIPTION
Possible Bug fix for : Overlapping regions are getting fall outside the specified inner and outer radius of stack track when direction ='in'